### PR TITLE
Refresh homepage content and elevate exit.tech

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,18 +3,20 @@
 <html lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <base target="_blank">
   <title>Alisher Sherali</title>
   <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <meta name="description" content="Exits, beliefs, and decentralised tools.">
   <!-- Open Graph -->
-  <meta property="og:title" content="Alisher Sherali: Exits, beliefs, and decentralizing tools">
-  <meta property="og:description" content="Exits, beliefs, and decentralizing tools.">
+  <meta property="og:title" content="Alisher Sherali: Exits, beliefs, and decentralised tools">
+  <meta property="og:description" content="Exits, beliefs, and decentralised tools.">
   <meta property="og:image" content="https://alisher.sherali.xyz/assets/social-preview.jpg">
   <meta property="og:type" content="website">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Alisher Sherali">
-  <meta name="twitter:description" content="Exits, beliefs, and decentralizing tools.">
+  <meta name="twitter:description" content="Exits, beliefs, and decentralised tools.">
   <meta name="twitter:image" content="https://alisher.sherali.xyz/assets/social-preview.jpg">
   <style>
     body {
@@ -32,6 +34,34 @@
       margin-top: 2rem;
       margin-bottom: 0.5rem;
       color: #ffffff;
+    }
+    h1 {
+      margin-bottom: 0.25rem;
+    }
+    .roles {
+      color: #ff0079;
+      font-weight: 600;
+      font-size: 1.15rem;
+      letter-spacing: 0.01em;
+      margin: 0 0 1rem;
+    }
+    .tagline {
+      color: #b8b8b8;
+      font-size: 1.05rem;
+      margin-top: 0;
+    }
+    .feature {
+      border-left: 3px solid #ff0079;
+      background-color: #1a1a1a;
+      padding: 0.25rem 1.25rem 1rem;
+      margin: 2rem 0 0;
+      border-radius: 0 6px 6px 0;
+    }
+    .feature h3 {
+      margin-top: 1rem;
+    }
+    .feature p {
+      margin-bottom: 0;
     }
     a {
       color: #ff0079;
@@ -57,53 +87,54 @@
 <body>
   <div class="circle"></div>
   <h1>Alisher Sherali</h1>
-  <p><em>Enabling new ways of <strong>being</strong> - with care, structure, and coherence.<br>
-  Go deep. Move fast. Think katana, not tank.</em></p>
+  <p class="roles">builder · dad · farmer</p>
+  <p class="tagline"><em>I compress the distance between a vision and its proof.</em></p>
 
   <h2>Exits</h2>
-<p>Exited oppressive states, fled a war zone, survived a ghetto school, left behind two government-run universities, and walked away from million-user, state-affiliated megacorps after becoming disillusioned. Helped launch and move on from over a dozen startups across social networking, genetics, telemedicine, security, and crypto. Stopped fighting Russian propaganda alone, completed psychedelic explorations, and shed a series of redundant identities.</p>
+  <p>Fled a war zone when I was 7, survived a ghetto school in Penza, dropped two brainwashing government universities, and — once the disillusionment set in — exited the million-user, state-adjacent megacorps (VK Group and Yandex) I helped build. Left the oppressive Russian state behind. Walked through the years of deep depression with Nietzsche, Metzinger and the Bhagavad Gita. Helped launch and farewell a dozen-odd startups across social, law, genetics, telemedicine, security, and crypto. Finished the psychedelic fieldwork and the touring-DJ adventures; quit my Burning Man addiction (the event, not the spirit). Exited the growing number of proprietary ecosystems too, and wrote down how, so the next person leaves faster. Shed a few redundant identities on the way out.</p>
+
   <h2>Now</h2>
-  <p>Contributing to permissionless tech for a decentralized future.<br>
-Breathing in a space of shared beliefs.<br>
-Walking the field of ideas.<br>
-Participating in chains of trust.<br>
-That’s our air, land, and infrastructure.<br>
-Enough of states. It’s time for community.</p>
 
-  <h2>Active</h2>
+  <h3>Tariqa Farm</h3>
   <ul>
-    <li><strong>Status</strong> – Self-hosted, non-custodial apps<br>
-      <a href="https://status.app/">https://status.app/</a></li>
-    <li><strong>Keycard Shell</strong> – Air-gapped, modular open-source hardware wallet<br>
-      <a href="https://keycard.tech/">https://keycard.tech/</a></li>
-    <li><strong>Aside</strong> – Quick chat for sensitive topics. My personal open-source experiment in radical privacy, openness, and minimalism<br>
-      <a href="https://aside.cc/">https://aside.cc/</a></li>
-    <li><strong>Contributor Experience Design at Logos</strong> – Initiative to make contributing to open-source projects less painful, more enjoyable, and more meaningful<br>
-      <a href="https://zealous-polka-dc7.notion.site/contributor-experience-design">https://zealous-polka-dc7.notion.site/contributor-experience-design</a></li>
-    <li><strong>Sound &amp; Stories</strong> – Exploring sound, rhythm, and story to weave diverse experiences for my communities<br>
-      <a href="https://soundcloud.com/alisherrr">https://soundcloud.com/alisherrr</a></li>
-  </ul>
-  <p>Committed to design, strategy, research, testing, content, and ecosystem building - crafting tools that open doors to participation, exploration, and sovereignty.</p>
-  <p>All my projects are open to collaboration. DM me or fork something.</p>
-
-  <h2>Values</h2>
-  <ul>
-    <li>Calm in chaos, chaos in calm.</li>
-    <li>Empathy in process. I love to listen. Tell me your story.</li>
-    <li>Vision with execution. Walk the walk.</li>
-    <li>Leading by example. Practice what you preach.</li>
-    <li><em>Build with care. Have fun along the way.</em></li>
+    <li>On five hectares in southern Spain, orange groves and pine hills, restoring a 120yo farm toward self-sufficiency — organic oranges, water, power, food, bees, spaces for volunteers and rituals. Moving toward connecting into the network of hyperlocal communities.</li>
+    <li>Self-hosting maxi. Running my own servers and inference infra, built from gaming PCs, old consoles and office junk. Open-source LLMs, agents, all kinds of FOSS, and my own tools.</li>
+    <li>Tinkering with mesh, solar and off-grid tech.</li>
+    <li>Stewarding the growth of two happy kids.</li>
   </ul>
 
-    <h2>Connect</h2>
-    <ul>
-      <li><a href="https://status.app/u/CwmAChEKD0FsaXNoZXIgU2hlcmFsaQM=#zQ3shWBWbQjMhpevjRT3KifqunFR8F81hbwzRMs7193PgWrhf">https://status.app/u/CwmAChEKD0FsaXNoZXIgU2hlcmFsaQM=#zQ3shWBWbQjMhpevjRT3KifqunFR8F81hbwzRMs7193PgWrhf</a></li>
-      <li><a href="https://github.com/xAlisher/">https://github.com/xAlisher/</a></li>
-      <li><a href="https://x.com/alisher">https://x.com/alisher</a></li>
-      <li><a href="https://www.linkedin.com/in/alishersherali/">https://www.linkedin.com/in/alishersherali/</a></li>
-      <li><a href="https://www.strava.com/athletes/alisher">https://www.strava.com/athletes/alisher</a></li>
-      <li><a href="https://app.metri.xyz/p/0x69B577044a84b0c7fAa7B85335bdc7BAfFb97548">https://app.metri.xyz/p/0x69B577044a84b0c7fAa7B85335bdc7BAfFb97548</a></li>
-    </ul>
+  <h3>Contributing to the Institute of Free Technology</h3>
+  <ul>
+    <li><a href="https://logos.co/"><strong>Logos</strong></a> — as an EcoDev: mapping the stack's capabilities to real needs, building Basecamp modules, red-teaming docs and nodes, breaking things on purpose and by accident, feeding what works to the community and what's missing back to the people building it.</li>
+    <li><a href="https://keycard.tech/"><strong>Keycard</strong></a> — as UX/UI designer and content creator. Just because it's the best cypherpunk hardware wallet on this planet — prove me wrong.</li>
+    <li><a href="https://status.app/"><strong>Status</strong></a> — as UX/UI designer and user researcher. Status was my “gateway drug” into the IFT ecosystem 5 years ago. I still hold the understanding of what change it can make to the world, and contribute toward it — no matter what happens along the way.</li>
+  </ul>
+
+  <p><strong>Contributing to <a href="https://web3privacy.info/">web3privacy</a></strong> — as a volunteer coordinator, think-tank contributor, amplifying force and helping hand at Cypherpunk events.</p>
+
+  <div class="feature">
+    <h3>Building <a href="https://exit.tech/">exit.tech</a></h3>
+    <p>Field guides for leaving walled gardens — so the next person exits faster.</p>
+  </div>
+
+  <h2>Cornerstones</h2>
+  <ul>
+    <li>Autonomy over alignment — outcomes over politics.</li>
+    <li>Find the gap and fill it — don't wait for permission.</li>
+    <li>Proof before promises — walk first, talk second.</li>
+    <li>Build with care. Have fun along the way.</li>
+  </ul>
+
+  <h2>Connect</h2>
+  <ul>
+    <li><a href="https://matrix.to/#/@alisher_sherali:matrix.org">https://matrix.to/#/@alisher_sherali:matrix.org</a></li>
+    <li><a href="https://status.app/u/CwmAChEKD0FsaXNoZXIgU2hlcmFsaQM=#zQ3shWBWbQjMhpevjRT3KifqunFR8F81hbwzRMs7193PgWrhf">https://status.app/u/CwmAChEKD0FsaXNoZXIgU2hlcmFsaQM=#zQ3shWBWbQjMhpevjRT3KifqunFR8F81hbwzRMs7193PgWrhf</a></li>
+    <li><a href="https://github.com/xAlisher/">https://github.com/xAlisher/</a></li>
+    <li><a href="https://x.com/alisher">https://x.com/alisher</a></li>
+    <li><a href="https://www.linkedin.com/in/alishersherali/">https://www.linkedin.com/in/alishersherali/</a></li>
+    <li><a href="https://www.strava.com/athletes/alisher">https://www.strava.com/athletes/alisher</a></li>
+    <li><a href="https://soundcloud.com/alisherrr">https://soundcloud.com/alisherrr</a></li>
+  </ul>
 
 
 </body></html>


### PR DESCRIPTION
Refreshes the site copy with the new bio and lifts `exit.tech` into a featured callout. Design (dark theme, pink accent, typography) kept intact.

## Changes
- **Copy**: rewrote Exits / Now / Cornerstones / Connect.
- **Header**: name → pink `builder · dad · farmer` roles line → italic tagline.
- **Now**: wrapped links into project names (Logos / Keycard / Status / web3privacy / exit.tech); deliberate emphasis ladder — Farm + IFT subsections, web3privacy line, **exit.tech** featured callout.
- **Cornerstones**: sharpened from 5 to 4 tight lines, echoing the "proof" tagline.
- **Links**: all open in new tabs via `<base target="_blank">`.
- **Meta**: description → "Exits, beliefs, and decentralised tools."
- Renamed Farm → **Tariqa Farm**.

Reviewed locally before push.

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)