### PR TITLE
SEO: structured data, canonical, sitemap/robots, fix social-image domain

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,20 +4,46 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <base target="_blank">
-  <title>Alisher Sherali</title>
+  <title>Alisher Sherali — builder, dad, farmer</title>
+  <link rel="canonical" href="https://alisher.xyz/">
   <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
   <meta name="description" content="Exits, beliefs, and decentralised tools.">
   <!-- Open Graph -->
-  <meta property="og:title" content="Alisher Sherali: Exits, beliefs, and decentralised tools">
+  <meta property="og:title" content="Alisher Sherali — builder, dad, farmer">
   <meta property="og:description" content="Exits, beliefs, and decentralised tools.">
-  <meta property="og:image" content="https://alisher.sherali.xyz/assets/social-preview.jpg">
+  <meta property="og:image" content="https://alisher.xyz/assets/social-preview.jpg">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:url" content="https://alisher.xyz/">
   <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Alisher Sherali">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Alisher Sherali">
+  <meta name="twitter:title" content="Alisher Sherali — builder, dad, farmer">
   <meta name="twitter:description" content="Exits, beliefs, and decentralised tools.">
-  <meta name="twitter:image" content="https://alisher.sherali.xyz/assets/social-preview.jpg">
+  <meta name="twitter:image" content="https://alisher.xyz/assets/social-preview.jpg">
+
+  <!-- Structured data: schema.org Person -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Alisher Sherali",
+    "url": "https://alisher.xyz/",
+    "image": "https://alisher.xyz/assets/social-preview.jpg",
+    "description": "Exits, beliefs, and decentralised tools.",
+    "jobTitle": "Builder",
+    "sameAs": [
+      "https://github.com/xAlisher/",
+      "https://x.com/alisher",
+      "https://www.linkedin.com/in/alishersherali/",
+      "https://www.strava.com/athletes/alisher",
+      "https://soundcloud.com/alisherrr",
+      "https://matrix.to/#/@alisher_sherali:matrix.org"
+    ]
+  }
+  </script>
   <style>
     body {
       font-family: system-ui, sans-serif;

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://alisher.xyz/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://alisher.xyz/</loc>
+    <lastmod>2026-07-01</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
Improves discoverability for the "Alisher Sherali" name query and fixes a non-canonical social-image domain.

## Changes
1. **JSON-LD Person schema** — feeds knowledge panel + wires social profiles via `sameAs`.
2. **Fixed social-image domain** — `alisher.sherali.xyz` → `alisher.xyz` (0 stale refs remain).
3. **Canonical URL** — dedupes the two live domains.
4. **Wider titles** — "Alisher Sherali — builder, dad, farmer".
5. **OG/Twitter completeness** — `og:url`, `og:site_name`, image dims, matched twitter:title.
6. **sitemap.xml + robots.txt**.

Validated: JSON-LD parses (Person, 6 sameAs), sitemap is well-formed XML.

Off-page (owner action, not in this PR): Search Console verify + submit; reciprocal sameAs links from social bios.

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)